### PR TITLE
anonymous user - log auth0 errors

### DIFF
--- a/src/utils/serverRunner.js
+++ b/src/utils/serverRunner.js
@@ -34,6 +34,9 @@ function handleProcessErrors(server) {
     logger.error(err, 'Uncaught exception in process, exiting');
     exit();
   });
+  process.on('unhandledRejection', function (err) {
+    logger.error(err, 'Unhandled rejection in process');
+  });
 }
 
 function startCluster(startServerFunc) {


### PR DESCRIPTION
The problem was that the updating process finishes after a response was returned.
In this stage, error-handler middleware is no longer active.

closes https://github.com/dorbel-tech/dorbel-app/issues/564