### PR TITLE
Save user pictures on our side

### DIFF
--- a/src/utils/user/helpers.js
+++ b/src/utils/user/helpers.js
@@ -16,7 +16,7 @@ function normalizePublicProfile(user) {
     first_name: _.get(user, 'user_metadata.first_name') || user.given_name,
     last_name: _.get(user, 'user_metadata.last_name') || user.family_name,
     phone: _.get(user, 'user_metadata.phone'),
-    picture: user.picture,
+    picture: getPermanentFBPictureUrl(user) || user.picture,
     tenant_profile: _.get(user, 'user_metadata.tenant_profile')
   };
 
@@ -28,6 +28,11 @@ function normalizePublicProfile(user) {
   }
 
   return publicProfile;
+}
+
+function getPermanentFBPictureUrl(user) {
+  const facebookData = _.find(user.identities, (identity) => identity.provider === 'facebook');
+  return facebookData ? `http://graph.facebook.com/${facebookData.user_id}/picture?type=large` : undefined;
 }
 
 function getTokenTTL(token) {

--- a/src/utils/user/helpers.js
+++ b/src/utils/user/helpers.js
@@ -30,6 +30,7 @@ function normalizePublicProfile(user) {
   return publicProfile;
 }
 
+// Created because Auth0 FB images expire after a period of time
 function getPermanentFBPictureUrl(user) {
   const facebookData = _.find(user.identities, (identity) => identity.provider === 'facebook');
   return facebookData ? `http://graph.facebook.com/${facebookData.user_id}/picture?type=large` : undefined;


### PR DESCRIPTION
Solution was to use a permanent url for the user's profile pic - using graph and his facebook user_id

connects to https://github.com/dorbel-tech/dorbel-app/issues/1391